### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -40,7 +40,7 @@ addColumn	KEYWORD2
 removeColumn	KEYWORD2
 columns	KEYWORD2
 columnIndex	KEYWORD2
-printColumns KEYWORD2
+printColumns	KEYWORD2
 
 ###################################################################
 # Constants


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords